### PR TITLE
Fix #6: `localStorage.setItem()` takes two parameters: the key, and the value.

### DIFF
--- a/sync.coffee
+++ b/sync.coffee
@@ -17,7 +17,7 @@ class bucket
         if not @clientid? or @clientid.indexOf("sjs") != 0
             @clientid = "sjs-#{@s.bversion}-#{@uuid(5)}"
             try
-                localStorage.setItem "#{@namespace}/clientid"
+                localStorage.setItem "#{@namespace}/clientid", @clientid
             catch error
                 console.log "#{@name}: couldnt set clientid"
 


### PR DESCRIPTION
See #6.
